### PR TITLE
Add slider for controlling base layer opacity.

### DIFF
--- a/public/map-controller/map-controller.js
+++ b/public/map-controller/map-controller.js
@@ -119,17 +119,16 @@ var MapController = P({
 
   get_admin_style_fcn: function() {
     var admin_to_color = this.map_coloring.active_base_layer_coloring_data();
-    var selected_admins = this.selected_admins;
-    return function(feature) {
+    return (function(feature) {
       var admin_code = feature.properties.admin_code;
       return {
         fillColor: admin_to_color[admin_code],
-        fillOpacity: 1,
+        fillOpacity: this.map_coloring.base_layer_opacity(),
         color: '#000',  // Border color.
         opacity: 1,
-        weight: selected_admins.get_border_weight(admin_code)
+        weight: this.selected_admins.get_border_weight(admin_code)
       };
-    };
+    }).bind(this);
   },
 
   build_epi_overlay_layer: function(epi_data) {

--- a/public/model/data-layer.js
+++ b/public/model/data-layer.js
@@ -13,6 +13,7 @@ var P = require('pjs').P;
 var DataLayer = P({
   init: function(on_update) {
     this.on_update = on_update;
+    this.base_opacity = 1.0;
     this.base_layer = 'weather';
     // `overlay_layers_status` is a map from all available overlays to a boolean
     // indicating whether layer is active.
@@ -46,6 +47,11 @@ var DataLayer = P({
       if (is_active) { active_layers.push(layer_name); }
     });
     return active_layers;
+  },
+
+  set_base_opacity: function(opacity) {
+    this.base_opacity = opacity;
+    this.on_update();
   },
 
   // TODO(jetpack): unit test that all valid layers return a name.

--- a/public/model/map-coloring.js
+++ b/public/model/map-coloring.js
@@ -31,6 +31,10 @@ var MapColoring = P({
       this.selected_date.current_day.toISOString());
   },
 
+  base_layer_opacity: function() {
+    return this.data_layer.base_opacity;
+  },
+
   /**
    * Returns a map from overlay layer name to data for that layer. The type of data varies for each
    * overlay layer.

--- a/public/view/overlay-controls/data-source-selector.css
+++ b/public/view/overlay-controls/data-source-selector.css
@@ -6,3 +6,8 @@ div.data-source-selector .btn {
     padding: 3px 6px;
     margin: 0 4px 0 4px;
 }
+
+#data-source-opacity {
+    display: inline;
+    width: 55%;
+}

--- a/public/view/overlay-controls/data-source-selector.jsx
+++ b/public/view/overlay-controls/data-source-selector.jsx
@@ -6,6 +6,13 @@ var DataSourceSelector = React.createClass({
     return this.props.data_layer.display_name(name);
   },
 
+  create_opacity_slider: function() {
+    return <input id="data-source-opacity" type="range" min="0" max="1" step="0.1"
+                  value={this.props.data_layer.base_opacity} onChange={(function(event) {
+                    this.props.data_layer.set_base_opacity(event.target.value);
+                  }).bind(this)} />;
+  },
+
   createBaseLayerOption: function(layer_name) {
     return <li key={layer_name}>
       <a href="#" onClick={
@@ -29,6 +36,7 @@ var DataSourceSelector = React.createClass({
 
   render: function() {
     return <div className="data-source-selector">
+      <div>Opacity: {this.create_opacity_slider()}</div>
       Data source:
       <div className="data-source-selector-base dropdown">
         <button type="button" className="btn btn-default dropdown-toggle" data-toggle="dropdown"


### PR DESCRIPTION
Choosing a basemap w/ roads and lowering opacity to ~20% is a cheap way to get a
road overlay. Also interesting to combine low opacity with the ESRI Imagery
basemap to see geographic features.

Note: based on `jetpack-global2` branch.